### PR TITLE
support for encodings in sign

### DIFF
--- a/lib/ssh_agent_client.js
+++ b/lib/ssh_agent_client.js
@@ -206,7 +206,9 @@ SSHAgentClient.prototype.requestIdentities = function(callback) {
  * @param {Function} callback of the form f(err, signature).
  * @throws {TypeError} on invalid arguments.
  */
-SSHAgentClient.prototype.sign = function(key, data, callback) {
+SSHAgentClient.prototype.sign = function(key, data, encoding, callback) {
+  if (typeof encoding === 'function')
+    return this.sign(key, data, null, encoding)
   if (!key || typeof(key) !== 'object')
     throw new TypeError('key (object) required');
   if (!data || typeof(data) !== 'object')
@@ -233,7 +235,7 @@ SSHAgentClient.prototype.sign = function(key, data, callback) {
 
     return callback(null, {
       type: type,
-      signature: signature.toString('base64'),
+      signature: encoding ? signature.toString(encoding) : signature,
       _raw: signature
     });
   }


### PR DESCRIPTION
Instead of defaulting to base64 for sign this PR defaults to buffers and adds an optional encoding parameter

``` js
agent.sign(key, new Buffer('hello world'), function(err, res) {
  // res.signature is a Buffer
})

agent.sign(key, new Buffer('hello world'), 'base64', function(err, res) {
  // res.signature is a base64 string
})
```
