### PR TITLE
Use default object when options is falsy

### DIFF
--- a/lib/ssh_agent_client.js
+++ b/lib/ssh_agent_client.js
@@ -124,9 +124,9 @@ function _writeHeader(request, tag) {
  * @constructor
  */
 function SSHAgentClient(options) {
-  if (options) {
-    this.timeout = options.timeout || 1000;
-  }
+  options = options || { timeout: 1000 };
+
+  this.timeout = options.timeout;
 
   this.sockFile = process.env.SSH_AUTH_SOCK;
   if (!this.sockFile)


### PR DESCRIPTION
The SSHAgentClient constructor did not set `this.timeout` when `options` was falsy which resulted in a TypeError when `#_request` called `Socket#setTimeout` with `undefined` as the first argument. This pull request adds an object containing the default value of `timeout` to remove the conditional, ensuring that `this.timeout` is set—unless `options` is truthy but not an object (e.g., a Number).

Fixes #3 (and the tests).
