### PR TITLE
fix possible undefined timeout

### DIFF
--- a/lib/ssh_agent_client.js
+++ b/lib/ssh_agent_client.js
@@ -124,9 +124,8 @@ function _writeHeader(request, tag) {
  * @constructor
  */
 function SSHAgentClient(options) {
-  if (options) {
-    this.timeout = options.timeout || 1000;
-  }
+  options = options || {};
+  this.timeout = options.timeout || 1000;
 
   this.sockFile = process.env.SSH_AUTH_SOCK;
   if (!this.sockFile)


### PR DESCRIPTION
as is, if `options` is not supplied, `this.timeout` will be `undefined` which can cause an error to be throw when `socket.setTimeout` is called with `undefined`.

from `node-manta`

```
TypeError: msecs must be a number
    at Object.exports.enroll (timers.js:156:11)
    at Socket.setTimeout (net.js:329:12)
    at SSHAgentClient._request (/Users/dave/dev/node-manta/node_modules/ssh-agent/lib/ssh_agent_client.js:300:10)
    at SSHAgentClient.requestIdentities (/Users/dave/dev/node-manta/node_modules/ssh-agent/lib/ssh_agent_client.js:186:15)
    at sshAgentGetKey (/Users/dave/dev/node-manta/lib/auth.js:216:12)
    at Object.checkAgentForKey [as func] (/Users/dave/dev/node-manta/lib/auth.js:450:17)
    at /Users/dave/dev/node-manta/node_modules/vasync/lib/vasync.js:191:20
    at process._tickCallback (node.js:355:11)
    at Function.Module.runMain (module.js:503:11)
    at startup (node.js:129:16)
```