### PR TITLE
requests that timeout can invoke callback more than once

### DIFF
--- a/lib/ssh_agent_client.js
+++ b/lib/ssh_agent_client.js
@@ -257,6 +257,7 @@ SSHAgentClient.prototype._request = function (getRequest,
   var self = this;
   var socket = net.createConnection(this.sockFile);
   var gotdata = false;
+  var timedout = false;
 
   socket.on('data', function (data) {
     gotdata = true;
@@ -280,7 +281,7 @@ SSHAgentClient.prototype._request = function (getRequest,
   });
 
   socket.on('close', function (haderror) {
-    if (!haderror && !gotdata) {
+    if (!haderror && !gotdata && !timedout) {
       callback(new InvalidProtocolError('No Response'));
     }
   });
@@ -294,7 +295,8 @@ SSHAgentClient.prototype._request = function (getRequest,
   });
 
   socket.setTimeout(this.timeout, function () {
-    socket.end();
+    timedout = true;
+    socket.destroy();
     var e = new TimeoutError('request timed out after: ' + self.timeout);
     return callback(e);
   });


### PR DESCRIPTION
We're seeing occasional errors with the node-manta clients where the program fails with "TypeError: not a buffer".  The exception is very disconnected from the real problem, so I described the details in node-manta#228.  The problem turned out to be that ssh-agent successfully connected, but only after the timeout had expired, and it ended up calling the user callback twice.  First, the 'timeout' callback was fired and the user's callback was called, but then the 'connect' callback _also_ fired.  I fixed this by changing the socket.end() in the timeout callback to a socket.destroy().  With that, I found that we were still crashing.  This time, the 'close' callback also called the user's callback.  So I also added a "timedout" boolean using the existing pattern that was used there.

I've been running this in a loop for a while now without reproducing the problem.
